### PR TITLE
Depend on logging instead of directly on ers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ daq_setup_environment()
 find_package(appfwk REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(msgpack REQUIRED)
-find_package(ers REQUIRED)
+find_package(logging REQUIRED)
 
 ##############################################################################
 # Schema
@@ -19,7 +19,7 @@ daq_codegen(*.jsonnet TEST TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 
 # We don't have a real library, but we want to create a target for
 # dependents to be able to depend on
-daq_add_library(LINK_LIBRARIES msgpackc-cxx nlohmann_json::nlohmann_json ers)
+daq_add_library(LINK_LIBRARIES msgpackc-cxx nlohmann_json::nlohmann_json logging::logging)
 
 ##############################################################################
 


### PR DESCRIPTION
This PR should fix dependencies in `CMakeLists.txt` so it builds