### PR TITLE
Add macro to make classes/structs serializable non-intrusively

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 
 This repository contains utilities for serializing/deserializing C++ objects for DUNE DAQ. Serialization allows objects to be sent across the network or persisted to disk.
 
-You'll need to edit your `dbt-settings` file to use the `msgpack_c` UPS product. Add `"/cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products_dev"` to `dune_products_dirs` and `"msgpack_c v3_3_0 e19:prof"` to `dune_products`. See https://github.com/DUNE-DAQ/appfwk/wiki/Compiling-and-running-under-v2.2.0#adding-extra-ups-products-and-product-pools for more information.
-
 ## Quick start
 
 An appropriately-defined C++ type (see below) can be serialized/deserialized as follows:
@@ -12,28 +10,12 @@ An appropriately-defined C++ type (see below) can be serialized/deserialized as 
  MyClass m;
  m.some_member=3;
  // ... set other parts of m...
- dunedaq::serialization::SerializationType stype=dunedaq::serialization::MsgPack; // or JSON, which is human-readable but slower
+ dunedaq::serialization::SerializationType stype=dunedaq::serialization::kMsgPack; // or kJSON, which is human-readable but slower
  std::vector<uint8_t> bytes=dunedaq::serialization::serialize(m, stype);
  
  // ...elsewhere, after receiving the serialized object:
- MyClass m_recv=dunedaq::serialization::deserialize<MyClass>(bytes, stype);
+ MyClass m_recv=dunedaq::serialization::deserialize<MyClass>(bytes);
 ```
-
-If you want to send/receive the serialized object over [IPM](https://github.com/DUNE-DAQ/ipm), `NetworkObjectSender<T>` and `NetworkObjectReceiver<T>` provide a convenience wrapper:
-
-```cpp
-// Sender process:
-NetworkObjectSender<FakeData> sender(sender_conf);
-FakeData fd;
-fd.fake_count=25;
-sender.send(fd, std::chrono::milliseconds(2));
-// Receiver process:
-NetworkObjectReceiver<FakeData> receiver(receiver_conf);
-FakeData fd_recv=receiver.recv(std::chrono::milliseconds(2));
-// Now fd_recv.fake_count==25
-```
-
-See [network_object_send_receive.cxx](./test/apps/network_object_send_receive.cxx) for a full example, including setting the `sender_conf` and `receiver_conf` objects.
 
 ## Making types serializable
 
@@ -43,23 +25,49 @@ If your type is specified via a `moo` schema, you just need to `moo render` your
 
 ### Without [`moo`](https://github.com/brettviren/moo)
 
-If your class is not specified via a `moo` schema, it can be made serializable by adding convertor functions for `nlohmann::json` and `msgpack`. (Right now, _both_ methods need to be implemented, even if you only plan to use one of them. Maybe this could be changed, but the serialization type can come from config, and might not necessarily be known at compile-time, so code for both has to be available). Full instructions for serializing arbitrary types with `nlohmann::json` are available [here](https://nlohmann.github.io/json/features/arbitrary_types/) and for `msgpack`, [here](https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_packer).
+If your class is not specified via a `moo` schema, it can be made serializable by adding convertor functions for `msgpack` and, optionally, `nlohmann::json`. If convertor functions are only provided for `msgpack` and not for `nlohmann::json`, json serialization is done by the serialization library: the object is converted to msgpack format and from there to json (and similarly to deserialize).
 
-The easiest way to achieve this is with the `DUNE_DAQ_SERIALIZE()` convenience macro provided in [`Serialization.hpp`](./include/serialization/Serialization.hpp):
+The easiest way to make your class (de)serializable is with the `DUNE_DAQ_SERIALIZE()` convenience macro provided in [`Serialization.hpp`](./include/serialization/Serialization.hpp):
 
 ```cpp
 // A type that's made serializable "intrusively", ie, by changing the type itself
+namespace ns {
 struct MyTypeIntrusive
 {
-  int i;
-  std::string s;
-  std::vector<double> v;
+  int some_int;
+  std::string some_string;
+  std::vector<double> some_vector;
 
-  DUNE_DAQ_SERIALIZE(MyTypeIntrusive, i, s, v);
+  DUNE_DAQ_SERIALIZE(MyTypeIntrusive, some_int, some_string, some_vector);
 };
+} // namespace ns
 ```
 
-A complete example can be found in [`non_moo_type.cxx`](./test/apps/non_moo_type.cxx), including an example of how to make a class serializable "non-intrusively", ie, without changes to the class itself.
+You may not be able to change the type itself, either because you
+don't have access to it, or because it lives in a package that cannot
+depend on the `serialization` package. In this case, you can use the
+`DUNE_DAQ_SERIALIZE_NON_INTRUSIVE()` macro instead. In the _global_
+namespace, call `DUNE_DAQ_SERIALIZE_NON_INTRUSIVE()` with first
+argument the namespace of your class, second argument the class name,
+and the rest of the arguments listing the member variables. For example:
+
+```cpp
+// A type that's made serializable "intrusively", ie, by changing the type itself
+namespace ns {
+struct MyType
+{
+  int some_int;
+  std::string some_string;
+  std::vector<double> some_vector;
+};
+} // namespace ns
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(ns, MyType, some_int, some_string, some_vector);
+```
+
+A complete example, showing both intrusive and non-intrusive strategies, can be found in [`non_moo_type.cxx`](./test/apps/non_moo_type.cxx).
+
+Full instructions for serializing arbitrary types with `nlohmann::json` are available [here](https://nlohmann.github.io/json/features/arbitrary_types/) and for `msgpack`, [here](https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_packer). These include instructions for (de)serializing classes that are not default-constructible.
 
 ## Design notes
 

--- a/include/serialization/Serialization.hpp
+++ b/include/serialization/Serialization.hpp
@@ -22,7 +22,7 @@
 #include "boost/preprocessor.hpp"
 
 /**
- * @brief Macro to make a class serializable
+ * @brief Macro to make a class/struct serializable intrusively
  *
  * Call the macro inside your class declaration, with the first
  * argument being the class name, followed by each of the member
@@ -42,9 +42,30 @@
   MSGPACK_DEFINE(__VA_ARGS__)                        \
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, __VA_ARGS__)
 
+// Helper macros for DUNE_DAQ_SERIALIZE_NON_INTRUSIVE()
 #define OPACK(r, data, elem) o.pack(m.elem);
 #define OUNPACK(r, data, elem) m.elem = o.via.array.ptr[i++].as<decltype(m.elem)>();
-    
+
+/**
+ * @brief Macro to make a class/struct serializable non-intrusively
+ *
+ * Call the macro outside your class declaration, from the global
+ * namespace. The first argument is the namespace of your class, the
+ * second is the class name, and the rest of the arguments list the
+ * member variables. Example:
+ *
+ *      namespace ns {
+ *      struct MyType
+ *      {
+ *        int i;
+ *        std::string s;
+ *        std::vector<double> v;
+ *      }
+ *      }
+ *
+ *      DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(ns, MyType, i, s, v);
+ *
+ */
 #define DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(NS, Type, ...)                     \
   namespace NS {  \
   NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, __VA_ARGS__) \

--- a/include/serialization/Serialization.hpp
+++ b/include/serialization/Serialization.hpp
@@ -38,8 +38,8 @@
  *      };
  *
  */
-#define DUNE_DAQ_SERIALIZE(Type, ...)                \
-  MSGPACK_DEFINE(__VA_ARGS__)                        \
+#define DUNE_DAQ_SERIALIZE(Type, ...)                                                                                  \
+  MSGPACK_DEFINE(__VA_ARGS__)                                                                                          \
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, __VA_ARGS__)
 
 // Helper macros for DUNE_DAQ_SERIALIZE_NON_INTRUSIVE()
@@ -66,43 +66,42 @@
  *      DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(ns, MyType, i, s, v);
  *
  */
-#define DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(NS, Type, ...)                     \
-  namespace NS {  \
-  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, __VA_ARGS__) \
-  } \
-    namespace msgpack { \
-    MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) \
-    { \
-      namespace adaptor { \
-      template<> \
-      struct pack<NS::Type>                     \
-      { \
-        template<typename Stream> \
-        packer<Stream>& operator()(msgpack::packer<Stream>& o, NS::Type const& m) const \
-        { \
-          o.pack_array(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)); \
-          BOOST_PP_SEQ_FOR_EACH(OPACK, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
-          return o; \
-        } \
-      }; \
-      template<> \
-        struct convert<NS::Type>                \
-      { \
-        msgpack::object const& operator()(msgpack::object const& o,  NS::Type& m) const \
-        { \
-          if (o.type != msgpack::type::ARRAY) \
-            throw msgpack::type_error(); \
-          if (o.via.array.size != BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)) \
-            throw msgpack::type_error(); \
-          int i=0; \
-          BOOST_PP_SEQ_FOR_EACH(OUNPACK, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
-          return o; \
-        } \
-      }; \
-      } \
-    } \
-}
-
+#define DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(NS, Type, ...)                                                                \
+  namespace NS {                                                                                                       \
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, __VA_ARGS__)                                                                \
+  }                                                                                                                    \
+  namespace msgpack {                                                                                                  \
+  MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)                                                                \
+  {                                                                                                                    \
+    namespace adaptor {                                                                                                \
+    template<>                                                                                                         \
+    struct pack<NS::Type>                                                                                              \
+    {                                                                                                                  \
+      template<typename Stream>                                                                                        \
+      packer<Stream>& operator()(msgpack::packer<Stream>& o, NS::Type const& m) const                                  \
+      {                                                                                                                \
+        o.pack_array(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__));                                                             \
+        BOOST_PP_SEQ_FOR_EACH(OPACK, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))                                          \
+        return o;                                                                                                      \
+      }                                                                                                                \
+    };                                                                                                                 \
+    template<>                                                                                                         \
+    struct convert<NS::Type>                                                                                           \
+    {                                                                                                                  \
+      msgpack::object const& operator()(msgpack::object const& o, NS::Type& m) const                                   \
+      {                                                                                                                \
+        if (o.type != msgpack::type::ARRAY)                                                                            \
+          throw msgpack::type_error();                                                                                 \
+        if (o.via.array.size != BOOST_PP_VARIADIC_SIZE(__VA_ARGS__))                                                   \
+          throw msgpack::type_error();                                                                                 \
+        int i = 0;                                                                                                     \
+        BOOST_PP_SEQ_FOR_EACH(OUNPACK, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))                                        \
+        return o;                                                                                                      \
+      }                                                                                                                \
+    };                                                                                                                 \
+    }                                                                                                                  \
+  }                                                                                                                    \
+  }
 
 namespace dunedaq {
 
@@ -124,8 +123,6 @@ ERS_DECLARE_ISSUE(serialization,                        // namespace
 ERS_DECLARE_ISSUE(serialization,                        // namespace
                   CannotDeserializeMessage,             // issue name
                   "Cannot deserialize message",)        // message
-
-
 
 // clang-format on
 
@@ -213,15 +210,15 @@ deserialize(const std::vector<CharType>& v)
   // the rest is the actual message
   switch (v[0]) {
     case serialization_type_byte(kJSON): {
-      try{
+      try {
         json j = json::parse(v.begin() + 1, v.end());
         return j.get<T>();
-      } catch(json::exception& e) {
+      } catch (json::exception& e) {
         throw CannotDeserializeMessage(ERS_HERE, e);
       }
     }
     case serialization_type_byte(kMsgPack): {
-      try{
+      try {
         // The lambda function here is of type `unpack_reference_func`
         // as described at
         // https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_unpacker#memory-management
@@ -233,17 +230,19 @@ deserialize(const std::vector<CharType>& v)
         // return true (ie, store a pointer in the MsgPack object; no
         // copy) everywhere. Doing so results in a factor ~2 speedup in
         // deserializing Fragment, which is just a large BIN field
-        msgpack::object_handle oh = msgpack::unpack((char*)(v.data() + 1),
-                                                    v.size() - 1,
-                                                    [](msgpack::type::object_type /*typ*/, std::size_t /*length*/, void* /*user_data*/) -> bool {return true;}); // NOLINT
+        msgpack::object_handle oh =
+          msgpack::unpack((char*)(v.data() + 1),
+                          v.size() - 1,
+                          [](msgpack::type::object_type /*typ*/, std::size_t /*length*/, void * /*user_data*/) -> bool {
+                            return true;
+                          }); // NOLINT
         msgpack::object obj = oh.get();
         return obj.as<T>();
-      } catch(msgpack::type_error& e) {
+      } catch (msgpack::type_error& e) {
         throw CannotDeserializeMessage(ERS_HERE, e);
-      } catch(msgpack::unpack_error& e){
+      } catch (msgpack::unpack_error& e) {
         throw CannotDeserializeMessage(ERS_HERE, e);
       }
-
     }
     default:
       throw UnknownSerializationTypeByte(ERS_HERE, (char)v[0]); // NOLINT

--- a/test/apps/non_moo_type.cxx
+++ b/test/apps/non_moo_type.cxx
@@ -1,10 +1,10 @@
 #include "serialization/Serialization.hpp"
 
 #include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
-#include <boost/preprocessor/variadic/to_seq.hpp>
-#include <boost/preprocessor/variadic/size.hpp>
 #include <boost/preprocessor/seq/cat.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/variadic/size.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
 
 namespace myns {
 
@@ -32,7 +32,6 @@ struct MyTypeNonIntrusive
 
 } // end namespace myns
 
-
 DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(myns, MyTypeNonIntrusive, count, name, values)
 
 template<class T>
@@ -48,18 +47,18 @@ roundtrip(dunedaq::serialization::SerializationType& stype)
 
   std::vector<uint8_t> bytes = ser::serialize(m, stype);
   T m_recv = ser::deserialize<T>(bytes);
-  bool ok=true;
-  if(m_recv.count != m.count){
+  bool ok = true;
+  if (m_recv.count != m.count) {
     std::cerr << "count does not match" << std::endl;
-    ok=false;
+    ok = false;
   }
-  if(m_recv.name != m.name){
+  if (m_recv.name != m.name) {
     std::cerr << "name does not match" << std::endl;
-    ok=false;
+    ok = false;
   }
-  if(m_recv.values != m.values){
+  if (m_recv.values != m.values) {
     std::cerr << "values does not match" << std::endl;
-    ok=false;
+    ok = false;
   }
   return ok;
 }
@@ -68,16 +67,15 @@ int
 main()
 {
   // Test all four combinations of { intrusive, non-intrusive } x { msgpack, json }
-  bool ok=true;
+  bool ok = true;
   for (auto stype : { dunedaq::serialization::kMsgPack, dunedaq::serialization::kJSON }) {
     ok = ok && roundtrip<myns::MyTypeIntrusive>(stype);
     ok = ok && roundtrip<myns::MyTypeNonIntrusive>(stype);
   }
-  if(!ok){
+  if (!ok) {
     std::cerr << "Failure" << std::endl;
     exit(1);
-  }
-  else{
+  } else {
     std::cout << "Success" << std::endl;
   }
   exit(0);

--- a/test/src/serialization/fsd/Msgp.hpp
+++ b/test/src/serialization/fsd/Msgp.hpp
@@ -10,70 +10,79 @@
 // My structs
 #include "serialization/fsd/Structs.hpp"
 
-
-
 #include <msgpack.hpp>
 
 MSGPACK_ADD_ENUM(dunedaq::serialization::fsd::Fakeness)
 
 // MsgPack serialization/deserialization functions
 namespace msgpack {
-MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
-namespace adaptor {
+MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+{
+  namespace adaptor {
 
-
-// MsgPack serialization for RECORD type:
-// dunedaq::serialization::fsd::FakeData
-template<>
-struct convert<dunedaq::serialization::fsd::FakeData> {
-    msgpack::object const& operator()(msgpack::object const& o, dunedaq::serialization::fsd::FakeData& v) const {
-        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        if (o.via.array.size != 1) throw msgpack::type_error();
-        v.fake_count = o.via.array.ptr[0].as<dunedaq::serialization::fsd::Count>();
-        return o;
+  // MsgPack serialization for RECORD type:
+  // dunedaq::serialization::fsd::FakeData
+  template<>
+  struct convert<dunedaq::serialization::fsd::FakeData>
+  {
+    msgpack::object const& operator()(msgpack::object const& o, dunedaq::serialization::fsd::FakeData& v) const
+    {
+      if (o.type != msgpack::type::ARRAY)
+        throw msgpack::type_error();
+      if (o.via.array.size != 1)
+        throw msgpack::type_error();
+      v.fake_count = o.via.array.ptr[0].as<dunedaq::serialization::fsd::Count>();
+      return o;
     }
-};
-template<>
-struct pack<dunedaq::serialization::fsd::FakeData> {
-    template <typename Stream>
-    packer<Stream>& operator()(msgpack::packer<Stream>& o, dunedaq::serialization::fsd::FakeData const& v) const {
-        // packing member variables as an array.
-        o.pack_array(1);
-        o.pack(v.fake_count);
-        return o;
+  };
+  template<>
+  struct pack<dunedaq::serialization::fsd::FakeData>
+  {
+    template<typename Stream>
+    packer<Stream>& operator()(msgpack::packer<Stream>& o, dunedaq::serialization::fsd::FakeData const& v) const
+    {
+      // packing member variables as an array.
+      o.pack_array(1);
+      o.pack(v.fake_count);
+      return o;
     }
-};
+  };
 
-// MsgPack serialization for RECORD type:
-// dunedaq::serialization::fsd::AnotherFakeData
-template<>
-struct convert<dunedaq::serialization::fsd::AnotherFakeData> {
-    msgpack::object const& operator()(msgpack::object const& o, dunedaq::serialization::fsd::AnotherFakeData& v) const {
-        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        if (o.via.array.size != 4) throw msgpack::type_error();
-        v.fake_count = o.via.array.ptr[0].as<dunedaq::serialization::fsd::Count>();
-        v.fake_timestamp = o.via.array.ptr[1].as<dunedaq::serialization::fsd::Timestamp>();
-        v.fake_datas = o.via.array.ptr[2].as<dunedaq::serialization::fsd::FakeDatas>();
-        v.fakeness = o.via.array.ptr[3].as<dunedaq::serialization::fsd::Fakeness>();
-        return o;
+  // MsgPack serialization for RECORD type:
+  // dunedaq::serialization::fsd::AnotherFakeData
+  template<>
+  struct convert<dunedaq::serialization::fsd::AnotherFakeData>
+  {
+    msgpack::object const& operator()(msgpack::object const& o, dunedaq::serialization::fsd::AnotherFakeData& v) const
+    {
+      if (o.type != msgpack::type::ARRAY)
+        throw msgpack::type_error();
+      if (o.via.array.size != 4)
+        throw msgpack::type_error();
+      v.fake_count = o.via.array.ptr[0].as<dunedaq::serialization::fsd::Count>();
+      v.fake_timestamp = o.via.array.ptr[1].as<dunedaq::serialization::fsd::Timestamp>();
+      v.fake_datas = o.via.array.ptr[2].as<dunedaq::serialization::fsd::FakeDatas>();
+      v.fakeness = o.via.array.ptr[3].as<dunedaq::serialization::fsd::Fakeness>();
+      return o;
     }
-};
-template<>
-struct pack<dunedaq::serialization::fsd::AnotherFakeData> {
-    template <typename Stream>
-    packer<Stream>& operator()(msgpack::packer<Stream>& o, dunedaq::serialization::fsd::AnotherFakeData const& v) const {
-        // packing member variables as an array.
-        o.pack_array(4);
-        o.pack(v.fake_count);
-        o.pack(v.fake_timestamp);
-        o.pack(v.fake_datas);
-        o.pack(v.fakeness);
-        return o;
+  };
+  template<>
+  struct pack<dunedaq::serialization::fsd::AnotherFakeData>
+  {
+    template<typename Stream>
+    packer<Stream>& operator()(msgpack::packer<Stream>& o, dunedaq::serialization::fsd::AnotherFakeData const& v) const
+    {
+      // packing member variables as an array.
+      o.pack_array(4);
+      o.pack(v.fake_count);
+      o.pack(v.fake_timestamp);
+      o.pack(v.fake_datas);
+      o.pack(v.fakeness);
+      return o;
     }
-};
+  };
 
-
-} // namespace adaptor
+  } // namespace adaptor
 } // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 } // namespace msgpack
 

--- a/unittest/Serialization_test.cxx
+++ b/unittest/Serialization_test.cxx
@@ -13,12 +13,12 @@
  */
 #define BOOST_TEST_MODULE Serialization_test // NOLINT
 
-#include "boost/test/unit_test.hpp"
 #include "boost/test/data/test_case.hpp"
+#include "boost/test/unit_test.hpp"
 
 #include <string>
-#include <vector>
 #include <thread>
+#include <vector>
 
 // A type that's made serializable "intrusively", ie, by changing the type itself
 struct MyTypeIntrusive
@@ -32,11 +32,11 @@ struct MyTypeIntrusive
 
 BOOST_AUTO_TEST_SUITE(Serialization_test)
 
-
 /**
  * @brief Check that we can serialize -> deserialize and get back what we started with
  */
-BOOST_DATA_TEST_CASE(SerializationRoundTrip, boost::unit_test::data::make({dunedaq::serialization::kMsgPack, dunedaq::serialization::kJSON}))
+BOOST_DATA_TEST_CASE(SerializationRoundTrip,
+                     boost::unit_test::data::make({ dunedaq::serialization::kMsgPack, dunedaq::serialization::kJSON }))
 {
 
   MyTypeIntrusive m;
@@ -49,32 +49,33 @@ BOOST_DATA_TEST_CASE(SerializationRoundTrip, boost::unit_test::data::make({duned
 
   std::vector<uint8_t> bytes = ser::serialize(m, sample);
   MyTypeIntrusive m_recv = ser::deserialize<MyTypeIntrusive>(bytes);
-  BOOST_CHECK_EQUAL(m_recv.count,  m.count);
-  BOOST_CHECK_EQUAL(m_recv.name,   m.name);
-  BOOST_CHECK_EQUAL_COLLECTIONS(m_recv.values.begin(), m_recv.values.end(),
-                                m.values.begin(), m.values.end());
-
+  BOOST_CHECK_EQUAL(m_recv.count, m.count);
+  BOOST_CHECK_EQUAL(m_recv.name, m.name);
+  BOOST_CHECK_EQUAL_COLLECTIONS(m_recv.values.begin(), m_recv.values.end(), m.values.begin(), m.values.end());
 }
 
 BOOST_AUTO_TEST_CASE(InvalidSerializationTypes)
 {
-  BOOST_CHECK_THROW(dunedaq::serialization::from_string("not a real type"), dunedaq::serialization::UnknownSerializationTypeString);
+  BOOST_CHECK_THROW(dunedaq::serialization::from_string("not a real type"),
+                    dunedaq::serialization::UnknownSerializationTypeString);
 
   // The first byte, which indicates the message serialization type,
   // should be 'M' or 'J': check we get an exception when it's not
-  std::vector<char> invalid_message={'0', '2', '3', '4'};
-  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_message), dunedaq::serialization::UnknownSerializationTypeByte);
+  std::vector<char> invalid_message = { '0', '2', '3', '4' };
+  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_message),
+                    dunedaq::serialization::UnknownSerializationTypeByte);
 
-  std::vector<char> invalid_json_message={'J', ']', '[', '4'};
-  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_json_message), dunedaq::serialization::CannotDeserializeMessage);
+  std::vector<char> invalid_json_message = { 'J', ']', '[', '4' };
+  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_json_message),
+                    dunedaq::serialization::CannotDeserializeMessage);
 
   // An invalid msgpack message: we have our serialization type byte,
   // 'M', followed by 0xce, which indicates that a four-byte integer
   // follows. But we only have two more bytes after that, so the
   // message is invalid
-  std::vector<unsigned char> invalid_msgpack_message={'M', 0xce, 0x0, 0x0};
-  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_json_message), dunedaq::serialization::CannotDeserializeMessage);
-
+  std::vector<unsigned char> invalid_msgpack_message = { 'M', 0xce, 0x0, 0x0 };
+  BOOST_CHECK_THROW(dunedaq::serialization::deserialize<int>(invalid_json_message),
+                    dunedaq::serialization::CannotDeserializeMessage);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a macro to create the MsgPack and JSON serialization/deserialization functions for a class/struct non-intrusively, ie without changing the class itself. The current use-case is for types in `dataformats`, where the package cannot depend on `serialization` (a companion PR to this one in `dfmessages` shows an example of use, and there's doxygen documentation in the code).

The advantage of the new `DUNE_DAQ_SERIALIZE_NON_INTRUSIVE()` macro is a reduction in code that has to be written, and therefore hopefully a reduced opportunity for bugs.

The new macro is limited to default-constructible types with all member variables public. For non-default-constructible types, like `dataformats::Fragment`, the MsgPack/JSON functions have to be written out as before.

The macro implementation uses Boost.Preprocessor hackery. I expect this means that any mistakes made in using the macro will result in difficult-to-understand compiler messages, but I think the advantages are worth this cost.