### PR TITLE
copies of omsgp.hpp.j2, onljs.hpp.j2, and ostructs.hpp.j2 from moo

### DIFF
--- a/schema/serialization/MsgPack.hpp.j2
+++ b/schema/serialization/MsgPack.hpp.j2
@@ -1,0 +1,112 @@
+{% import 'ocpp.hpp.j2' as cppm %}
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for schema in
+ * {{cppm.ns(model)}} to be serialized via MsgPack.
+ */
+{% set tcname = "MsgPack" %}
+#ifndef {{cppm.headerguard(model, tcname)}}
+#define {{cppm.headerguard(model, tcname)}}
+
+// My structs
+{% if model.ctxpath %}
+#include "{{ model.path|relpath(model.ctxpath)|join("/") }}/Structs.hpp"
+{% else %}
+#include "Structs.hpp"
+{% endif %}
+
+{% if model.extrefs %}
+// {{tcname}} for externally referenced schema
+{% endif %}
+{% for ep in model.extrefs %}
+{% if ep %}
+#include "{{ep|listify|join("/")}}/{{tcname}}.hpp"
+{% else %}
+#include "{{tcname}}.hpp"
+{% endif %}
+{% endfor %}
+
+{% if model.byscn.any %}
+// We have ANY types so need to include NLJS serialization
+{% if model.ctxpath %}
+#include "{{ model.path|relpath(model.ctxpath)|join("/") }}/Nljs.hpp"
+{% else %}
+#include "Nljs.hpp"
+{% endif %}
+{% endif %}
+
+#include <msgpack.hpp>
+
+{% for fqn in model.byscn.enum %}
+MSGPACK_ADD_ENUM({{fqn|replace(".","::")}})
+{% endfor %}
+
+// MsgPack serialization/deserialization functions
+namespace msgpack {
+MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
+namespace adaptor {
+
+{% for fqn in model.byscn.any %}
+{% set a = model.byref[fqn] %}
+{% set fqncpp = fqn|listify|join("::") %}
+// {{tcname}} serialization for ANY type:
+// {{fqncpp}}
+template<>
+struct convert<{{fqncpp}}> {
+    msgpack::object const& operator()(msgpack::object const& o, {{fqncpp}}& v) const {
+        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+        if (o.via.array.size != 1) throw msgpack::type_error();
+        v={{fqncpp}}::parse(o.via.array.ptr[0].as<std::string>());
+        return o;
+    }
+};
+template<>
+struct pack<{{fqncpp}}> {
+    template <typename Stream>
+    packer<Stream>& operator()(msgpack::packer<Stream>& o, {{fqncpp}} const& v) const {
+        // packing member variables as an array.
+        o.pack_array(1);
+        o.pack(v.dump());
+        return o;
+    }
+};
+
+{% endfor %}
+
+{% for fqn in model.byscn.record %}
+{% set r = model.byref[fqn] %}
+{% set fqncpp = fqn|listify|join("::") %}
+// {{tcname}} serialization for RECORD type:
+// {{fqncpp}}
+template<>
+struct convert<{{fqncpp}}> {
+    msgpack::object const& operator()(msgpack::object const& o, {{fqncpp}}& v) const {
+        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+        if (o.via.array.size != {{ r.fields|length }}) throw msgpack::type_error();
+        {% for f in r.fields %}
+        v.{{f.name}} = o.via.array.ptr[{{loop.index0}}].as<{{f.item|replace(".","::")}}>();
+        {% endfor %}
+        return o;
+    }
+};
+template<>
+struct pack<{{fqncpp}}> {
+    template <typename Stream>
+    packer<Stream>& operator()(msgpack::packer<Stream>& o, {{fqncpp}} const& v) const {
+        // packing member variables as an array.
+        o.pack_array({{ r.fields|length }});
+        {% for f in r.fields %}
+        o.pack(v.{{ f.name }});
+        {% endfor %}
+        return o;
+    }
+};
+
+{% endfor %}
+
+} // namespace adaptor
+} // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+} // namespace msgpack
+
+#endif // {{cppm.headerguard(model, tcname)}}

--- a/schema/serialization/Nljs.hpp.j2
+++ b/schema/serialization/Nljs.hpp.j2
@@ -1,0 +1,77 @@
+{% import 'ocpp.hpp.j2' as cppm %}
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * {{cppm.ns(model)}} to be serialized via nlohmann::json.
+ */
+{% set tcname = "Nljs" %}
+#ifndef {{cppm.headerguard(model, tcname)}}
+#define {{cppm.headerguard(model, tcname)}}
+
+// My structs
+{% set ctxpath = model.ctxpath or [] %}
+{% set prefix = model.path|relpath(ctxpath)|join("/") %}
+{% if prefix %}
+#include "{{ prefix }}/Structs.hpp"
+{% else %}
+#include "Structs.hpp"
+{% endif %}
+
+{% if model.extrefs %}
+// {{tcname}} for externally referenced schema
+{% endif %}
+{% for ep in model.extrefs %}
+{% if ep %}
+#include "{{ep|listify|join("/")}}/{{tcname}}.hpp"
+{% else %}
+#include "{{tcname}}.hpp"
+{% endif %}
+{% endfor %}
+
+#include <nlohmann/json.hpp>
+
+{{ cppm.ns(model) }} {
+
+    using data_t = nlohmann::json;
+
+    {%- for fqn in model.byscn.enum -%}
+    {%- set e = model.byref[fqn] -%}
+    {% set n = fqn|listify|relpath(model.path)|join("::") %}
+    NLOHMANN_JSON_SERIALIZE_ENUM( {{n}}, {
+            {% for sname in e.symbols %}
+            { {{"::".join(model.path)}}::{{n}}::{{sname}}, "{{sname}}" },
+            {% endfor %}
+        })
+    {% endfor %}
+
+    {% for fqn in model.byscn.record %}    
+    {% set r = model.byref[fqn] %}
+    {% set n = fqn|listify|relpath(model.path)|join("::") %}
+    inline void to_json(data_t& j, const {{n}}& obj) {
+        {% for b in r.fields if b.name.startswith("_base_") %}
+        to_json(j, (const {{b.type}}&)obj);
+        {% endfor %}
+        {% for f in r.fields if not f.name.startswith("_base_") %}
+        j["{{f.name}}"] = obj.{{f.name}};
+        {% endfor%}
+    }
+    
+    inline void from_json(const data_t& j, {{r.name}}& obj) {
+        {% for b in r.fields if b.name.startswith("_base_") %}
+        from_json(j, ({{b.type}}&)obj);
+        {% endfor %}
+        {% for f in r.fields if not f.name.startswith("_base_") %}
+        {% if f.item in model.byscn.any %}
+        obj.{{f.name}} = j.at("{{f.name}}");
+        {% else %}
+        if (j.contains("{{f.name}}"))
+            j.at("{{f.name}}").get_to(obj.{{f.name}});    
+        {% endif %}
+        {% endfor%}
+    }
+    {% endfor %}
+    
+} // {{ cppm.ns(model) }}
+
+#endif // {{cppm.headerguard(model, tcname)}}

--- a/schema/serialization/Structs.hpp.j2
+++ b/schema/serialization/Structs.hpp.j2
@@ -1,0 +1,32 @@
+{% import 'ocpp.hpp.j2' as cppm %}
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for shema in 
+ * {{cppm.ns(model)}}.
+ */
+{% set tcname = "Structs" %}
+#ifndef {{cppm.headerguard(model, tcname)}}
+#define {{cppm.headerguard(model, tcname)}}
+
+#include <cstdint>
+{% for ep in model.extrefs %}
+#include "{{ep|listify|relpath(model.extpath)|join("/")}}/{{tcname}}.hpp"
+{% endfor %}
+
+{% for schema, typeref in model.byscn.items() %}
+{% if typeref %}{% for imp in model.lang.imports.get(schema, []) %}
+#include <{{imp}}>
+{% endfor %}{% endif %}
+{% endfor %}
+
+{{ cppm.ns(model) }} {
+
+    {% for t in model.types %}
+    // @brief {{ t.doc }}
+    {{ cppm["declare_"+t.schema](model, t)|indent }}
+
+    {% endfor %}
+} // {{ cppm.ns(model) }}
+
+#endif // {{cppm.headerguard(model, tcname)}}


### PR DESCRIPTION
This packages now hosts three templates (below) previously held in `moo`.

`MsgPack.hpp.j2`, `Nljs.hpp.j2`, `Structs.hpp.j2`

Further details in `moo` issue: https://github.com/brettviren/moo/issues/35. 