### PR TITLE
Eric's clang format fixes

### DIFF
--- a/include/serialization/serialize_variant.hpp
+++ b/include/serialization/serialize_variant.hpp
@@ -50,7 +50,8 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
     // called, but the compiler needs to see it
     template<typename VariantType>
     void set_variant_helper(std::size_t, msgpack::object const&, VariantType&&) const
-    {}
+    {
+    }
 
     // Deserializing std::variant is tricky, because we only know the
     // index of the type that's held at runtime. We want something that is effectively:
@@ -111,7 +112,8 @@ struct adl_serializer<std::variant<Args...>>
   // called, but the compiler needs to see it
   template<typename VariantType>
   static void set_variant_helper(std::size_t, nlohmann::json const&, VariantType&&)
-  {}
+  {
+  }
 
   template<typename VariantType, typename T, typename... Types>
   static void set_variant_helper(std::size_t i, nlohmann::json const& j, VariantType&& v)


### PR DESCRIPTION
This PR is for Eric's branch eflumerf/ClangFormat with which he had run dbt-clang-format.sh in sourcecode, run unit tests and integration tests.