### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/serialization/Serialization.hpp
+++ b/include/serialization/Serialization.hpp
@@ -11,6 +11,7 @@
 #define SERIALIZATION_INCLUDE_SERIALIZATION_SERIALIZATION_HPP_
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "boost/preprocessor.hpp"
 #include "msgpack.hpp"

--- a/include/serialization/Serialization.hpp
+++ b/include/serialization/Serialization.hpp
@@ -11,7 +11,7 @@
 #define SERIALIZATION_INCLUDE_SERIALIZATION_SERIALIZATION_HPP_
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "boost/preprocessor.hpp"
 #include "msgpack.hpp"


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)